### PR TITLE
kafka_produce_batch calls incorrect lib function.

### DIFF
--- a/kafka.c
+++ b/kafka.c
@@ -502,7 +502,7 @@ int kafka_produce_batch(rd_kafka_t *r, char *topic, char **msg, int *msg_len, in
             messages[i].payload = msg[i];
             messages[i].len = msg_len[i];
         }
-        i = rd_kafka_produce(rkt, partition, RD_KAFKA_MSG_F_COPY, messages, msg_cnt, NULL, 0, opaque);
+        i = rd_kafka_produce_batch(rkt, partition, RD_KAFKA_MSG_F_COPY, messages, msg_cnt);
         if (i < msg_cnt)
         {
             if (log_level)


### PR DESCRIPTION
function kafka_produce_batch calls incorrect lib function.  It's currently calling rd_kafka_produce.  It should call rd_kafka_produce_batch.  Tested successfully.
